### PR TITLE
Allow use of environment variables instead of using config.json

### DIFF
--- a/scraper/config.py
+++ b/scraper/config.py
@@ -20,7 +20,7 @@ def uses_env_vars():
     return reduce(lambda i,j: i and j,
         map(lambda k: os.environ.get(k) != None, ENV_VARIABLES))
 
-def environ_config():
+def env_config():
     return {
         'db_uri': os.environ[ENV_DB_URI],
         'db_name': os.environ[ENV_DB_NAME],
@@ -32,7 +32,7 @@ def environ_config():
 
 def load():
     if uses_env_vars():
-        return environ_config()
+        return env_config()
     else:
         with open('config.json','r') as f:
             return json.loads(f.read())


### PR DESCRIPTION
If you want to use this in a service like Heroku, keeping `config.json` in your repo is not desirable.

Modified `config.py` to check for certain defined environment variables that map to to the required options in `config.json`.

If all of the environment variables are defined, use the information from the environment variables instead of `config.json`

If not all of environment variables are defined, try to read `config.json`. 
