### PR TITLE
inspection-parse

### DIFF
--- a/scraper/items.py
+++ b/scraper/items.py
@@ -16,6 +16,16 @@ class HealthDistrictItem(Item):
 	vendor_status = Field()
 	vendor_phone = Field()
 
+	inspection_date = Field()
+	facility_type = Field()
+	year_round_status = Field()
+	risk_rating = Field()
+	inspection_type = Field()
+	followup_required = Field()
+
+	#To be deleted
+	inspection_url = Field()
+
 
 class DistrictItemLoader(ItemLoader):
 	default_item_class = HealthDistrictItem

--- a/scraper/spiders/healthspace_spider.py
+++ b/scraper/spiders/healthspace_spider.py
@@ -19,10 +19,11 @@ class HealthSpaceSpider(scrapy.Spider):
         2) Identify any anchor URLs and return them to the parse function
         3) Extract and identify any Javascript URLs in span tags and return
            them to the parse function
-        TODO: Read HTML body;
-        Identify URL's in <span> tags
-        Extract URL from JS Function
-        Pass URL list
+        '''
+
+        '''
+        This runs pretty linearly straight down the file, each function calls the one beneath it
+        the final item loader passes a loaded item all the way back up to get output
         '''
 
         ### Initial parse of district pages
@@ -49,6 +50,7 @@ class HealthSpaceSpider(scrapy.Spider):
         the district.
         '''
         
+        #### Push past district splash page.
         district_loader = response.meta['district_loader']
         vendor_catalog_url = response.urljoin('web.nsf/module_facilities.xsp?module=Food')
 
@@ -73,14 +75,19 @@ class HealthSpaceSpider(scrapy.Spider):
         if js_urls is not None:
             urls.extend(js_urls)
 
-        #Initiate vendor pipeline for each URL
+        #Push to Vendor Pages
         for url in urls:
-            district_name_to_vendor = district_loader.get_output_value('district_name')
-            district_link_to_vendor = district_loader.get_output_value('district_link')
 
+            #Extract items from loader as is
+            district_name_temp = district_loader.get_output_value('district_name')
+            district_link_temp = district_loader.get_output_value('district_link')
+            district_id_temp = district_loader.get_output_value('district_id')
+
+            #OUT WITH THE OLD IN WITH THE NEW! This is so hideously inefficient
             district_loader = DistrictItemLoader(selector = Selector(response))
-            district_loader.add_value('district_name', district_name_to_vendor)
-            district_loader.add_value('district_link', district_link_to_vendor)
+            district_loader.add_value('district_name', district_name_temp)
+            district_loader.add_value('district_link', district_link_temp)
+            district_loader.add_value('district_id', district_id_temp)
 
             vendor_url = response.urljoin(url)
             yield Request(vendor_url, callback=self.vendor_parser,
@@ -95,9 +102,7 @@ class HealthSpaceSpider(scrapy.Spider):
         district_loader = response.meta['district_loader']
         district_loader.selector = Selector(response)
 
-        test_url = response.url
-
-        district_loader.add_value('vendor_url', test_url)
+        district_loader.add_value('vendor_url', response.url)
         district_loader.add_xpath('vendor_name', '//tr/td/span[@id="view:_id1:_id175:nameCF1"]/text()')
         district_loader.add_xpath('vendor_location', '//tr/td/span[@id="view:_id1:_id175:facilityAddressCF1"]/text()')
         district_loader.add_xpath('vendor_id', '//tr/td/span[@id="view:_id1:_id175:documentIdCF1"]/text()')
@@ -106,6 +111,82 @@ class HealthSpaceSpider(scrapy.Spider):
         district_loader.add_xpath('vendor_status', '//tr/td/span[@id="view:_id1:_id175:statusCF1"]/text()')
         district_loader.add_xpath('vendor_phone', '//tr/td/span[@id="view:_id1:_id175:phoneCF1"]/text()')
 
+        ### Uncomment this to output all info up to vendor not including inspections
+        #yield district_loader.load_item()
+
+        #### Push to Inspection Pages.
+
+        # Get HTML links
+        urls = response.xpath('//tr/td/a/@href').extract()
+        # Get Javascript links
+        js_urls = js.get_urls(response)
+        if js_urls is not None:
+            urls.extend(js_urls)
+
+        district_loader.add_value('inspection_url', urls)
         yield district_loader.load_item()
+        #Initiate vendor pipeline for each URL
+        for url in urls:
+            inspection_url = response.urljoin(url)
+
+            #This is insane
+            district_name_to_temp = district_loader.get_output_value('district_name')
+            district_link_to_temp = district_loader.get_output_value('district_link')
+            district_id_temp = district_loader.get_output_value('district_id')
+            vendor_url_temp = district_loader.get_output_value('vendor_url')
+            vendor_name_temp = district_loader.get_output_value('vendor_name')
+            vendor_location_temp = district_loader.get_output_value('vendor_location')
+            vendor_id_temp = district_loader.get_output_value('vendor_id')
+            last_inspection_temp = district_loader.get_output_value('last_inspection')
+            vendor_type_temp = district_loader.get_output_value('vendor_type')
+            vendor_status_temp = district_loader.get_output_value('vendor_status')
+            vendor_phone_temp = district_loader.get_output_value('vendor_phone')
+
+            #When I figure out the clean solution for this I'm gonna feel so stupid
+            district_loader = DistrictItemLoader(selector = Selector(response))
+            district_loader.add_value('district_name', district_name_temp)
+            district_loader.add_value('district_link', district_link_temp)
+            district_loader.add_value('district_id', district_id_temp)
+            district_loader.add_value('vendor_url', vendor_url_temp)
+            district_loader.add_value('vendor_name', vendor_name_temp)
+            district_loader.add_value('vendor_location', vendor_location_temp)
+            district_loader.add_value('vendor_id', vendor_id_temp)
+            district_loader.add_value('last_inspection', last_inspection_temp)
+            district_loader.add_value('vendor_type', vendor_type_temp)
+            district_loader.add_value('vendor_status', vendor_status_temp)
+            district_loader.add_value('vendor_phone', vendor_phone_temp)
+
+            #Check to make sure we're hitting inspection pages
+            district_loader.add_value('inspection_url', inspection_url)
+
+            yield Request(inspection_url, callback=self.inspection_parser, meta={'district_loader':district_loader})
+
+
+    def inspection_parser(self, response):
+        district_loader = response.meta['district_loader']
+        district_loader.selector = Selector(response)
+
+        district_loader.add_xpath('inspection_date', '//*[@id="view:_id1:_id175:_id199:inspectionDateCF1"]/text()')
+        district_loader.add_xpath('facility_type', '//*[@id="view:_id1:_id175:_id199:facilityTypeCF1"]/text()')
+        district_loader.add_xpath('year_round_status', '//*[@id="view:_id1:_id175:_id199:allYearRoundCF1"]/text()')
+        district_loader.add_xpath('risk_rating', '//*[@id="view:_id1:_id175:_id199:riskRatingEB1"]/text()')
+        district_loader.add_xpath('inspection_type', '//*[@id="view:_id1:_id175:_id199:inspTypeCF1"]/text()')
+        district_loader.add_xpath('followup_required', '//*[@id="view:_id1:_id175:_id199:fuiReqCF1"]/text()')
+        
+        yield district_loader.load_item()
+
+    
+
+
+
+
+
+
+        
+
+
+
+
+
 
 


### PR DESCRIPTION
Problem extracting links to inspections from vendor page. Must look in the javascript helper file. Once the links are able to be extracted, this should return full info. 

To do
1) Fix links to inspection
2) Extract info from all tabs of inspection page (as of now just extracts from first tab)
3) Change inspection info so it is in dictionary form rather than new item for each inspection